### PR TITLE
Fix SocketClient.connect() ClassNotFoundException for Maven projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.2'
     compile 'com.google.code.gson:gson:2.8.5'
     compile 'com.google.protobuf:protobuf-lite:3.0.1'
-    compile 'io.grpc:grpc-okhttp:1.14.0'
+    compile ('io.grpc:grpc-okhttp:1.14.0') {
+        exclude group: 'com.squareup.okio', module:'okio'
+    }
+    compile 'com.squareup.okio:okio:1.14.0'
     compile 'com.squareup.okhttp3:okhttp:3.11.0'
     compile 'io.grpc:grpc-protobuf-lite:1.14.0'
     compile 'io.grpc:grpc-stub:1.14.0'


### PR DESCRIPTION
SocketClient.connect() throws exception because uses okio-1.13.0 instead of okio-1.14.0
```
Exception in thread "OkHttp Dispatcher" java.lang.NoClassDefFoundError: okio/Buffer$UnsafeCursor
	at okhttp3.internal.ws.WebSocketWriter.<init>(WebSocketWriter.java:71)
	at okhttp3.internal.ws.RealWebSocket.initReaderAndWriter(RealWebSocket.java:255)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:211)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:153)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: okio.Buffer$UnsafeCursor
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 8 more
```