### PR TITLE
Make GSON parse UTC properly from Nakama

### DIFF
--- a/src/main/java/com/heroiclabs/nakama/GsonDateDeserializer.java
+++ b/src/main/java/com/heroiclabs/nakama/GsonDateDeserializer.java
@@ -1,0 +1,31 @@
+package com.heroiclabs.nakama;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.logging.Logger;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+public class GsonDateDeserializer implements JsonDeserializer<Date> {
+
+	@Override
+	public Date deserialize(JsonElement element, Type arg1, JsonDeserializationContext arg2) throws JsonParseException {
+		String date = element.getAsString();
+
+		SimpleDateFormat formatter = new SimpleDateFormat("M/d/yy hh:mm a");
+		formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		try {
+			return formatter.parse(date);
+		}
+		catch (ParseException e) {
+			throw new JsonParseException("Could not deserialze DateTime.");
+		}
+	}
+}

--- a/src/main/java/com/heroiclabs/nakama/GsonDateDeserializer.java
+++ b/src/main/java/com/heroiclabs/nakama/GsonDateDeserializer.java
@@ -24,7 +24,7 @@ public class GsonDateDeserializer implements JsonDeserializer<Date> {
 			return formatter.parse(date);
 		}
 		catch (ParseException e) {
-			throw new JsonParseException("Could not deserialize DateTime.");
+			throw new JsonParseException("Could not deserialize Date.");
 		}
 	}
 }

--- a/src/main/java/com/heroiclabs/nakama/GsonDateDeserializer.java
+++ b/src/main/java/com/heroiclabs/nakama/GsonDateDeserializer.java
@@ -17,15 +17,14 @@ public class GsonDateDeserializer implements JsonDeserializer<Date> {
 	@Override
 	public Date deserialize(JsonElement element, Type arg1, JsonDeserializationContext arg2) throws JsonParseException {
 		String date = element.getAsString();
-
-		SimpleDateFormat formatter = new SimpleDateFormat("M/d/yy hh:mm a");
+		SimpleDateFormat formatter = new SimpleDateFormat("y-M-d'T'H:m:s'Z'");
 		formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 
 		try {
 			return formatter.parse(date);
 		}
 		catch (ParseException e) {
-			throw new JsonParseException("Could not deserialze DateTime.");
+			throw new JsonParseException("Could not deserialize DateTime.");
 		}
 	}
 }

--- a/src/main/java/com/heroiclabs/nakama/GsonDateDeserializer.java
+++ b/src/main/java/com/heroiclabs/nakama/GsonDateDeserializer.java
@@ -1,3 +1,19 @@
+/*
+* Copyright 2020 Heroic Labs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 package com.heroiclabs.nakama;
 
 import java.lang.reflect.Type;
@@ -5,13 +21,15 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
-import java.util.logging.Logger;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
+/*
+* A custom Date serializer to indicate to GSON that it is receiving UTC timestamps.
+*/
 public class GsonDateDeserializer implements JsonDeserializer<Date> {
 
 	@Override

--- a/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
+++ b/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
@@ -24,6 +24,7 @@ import com.google.gson.*;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.Timestamp;
+import com.google.type.Date;
 import com.heroiclabs.nakama.api.NotificationList;
 import com.heroiclabs.nakama.api.Rpc;
 import lombok.NonNull;
@@ -58,6 +59,7 @@ public class WebSocketClient implements SocketClient {
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .registerTypeHierarchyAdapter(byte[].class, new ByteArrayToBase64TypeAdapter())
             .setDateFormat("y-M-d'T'H:m:s'Z'")
+            .registerTypeAdapter(Date.class, new GsonDateDeserializer())
             .create();
 
     private final String host;

--- a/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
+++ b/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
@@ -58,7 +58,6 @@ public class WebSocketClient implements SocketClient {
     static final Gson GSON = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .registerTypeHierarchyAdapter(byte[].class, new ByteArrayToBase64TypeAdapter())
-            .setDateFormat("y-M-d'T'H:m:s'Z'")
             .registerTypeAdapter(Date.class, new GsonDateDeserializer())
             .create();
 

--- a/src/test/java/com/heroiclabs/nakama/NotificationTest.java
+++ b/src/test/java/com/heroiclabs/nakama/NotificationTest.java
@@ -29,6 +29,8 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import java.time.Instant;
+
 public class NotificationTest {
     private Client client;
     private Session session;
@@ -68,6 +70,10 @@ public class NotificationTest {
                 Assert.assertEquals(session.getUserId(), n.getSenderId());
                 Assert.assertNotNull(n.getCreateTime());
                 Assert.assertNotEquals(0, n.getCreateTime().getSeconds());
+
+                // should be within a couple seconds of one another
+                Assert.assertTrue(Instant.now().getEpochSecond() - n.getCreateTime().getSeconds() < 2);
+
                 latch.countDown();
             }
         }).get();

--- a/src/test/java/com/heroiclabs/nakama/NotificationTest.java
+++ b/src/test/java/com/heroiclabs/nakama/NotificationTest.java
@@ -72,7 +72,7 @@ public class NotificationTest {
                 Assert.assertNotEquals(0, n.getCreateTime().getSeconds());
 
                 // should be within a couple seconds of one another
-                Assert.assertTrue(Instant.now().getEpochSecond() - n.getCreateTime().getSeconds() < 2);
+                Assert.assertTrue(Math.abs(Instant.now().getEpochSecond() - n.getCreateTime().getSeconds()) < 2);
 
                 latch.countDown();
             }


### PR DESCRIPTION
We had reports of Timestamp issues when using Notifications.

I logged out the `createTime` property on notifications and noticed the client was reporting a UNIX time that was four hours ahead of the actual time as reported by the server.

It turns out that GSON simply appends the local time zone to whatever timestamp it parses, so a custom Date serializer is required to tell GSON that it is receiving UTC.