### PR TITLE
Remove protobuf-java transitive dependency and add configurable ping to socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Moved all external .proto dependencies into this repository.
 - Upgraded from Gradle 4 to Gradle 6.
 - Fixed bugs in Tournaments test suite.
+- Added configurable ping frame intervals to Web Socket.
+- Fixed incorrect time being parsed from timestamps.
+- Removed transitive dependency on Protobuf-Java.
+
 ## [2.0.4] - 2020-01-23
 ### Added
 - Updated gRPC, GSON and Lombok dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,10 @@ dependencies {
 
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.protobuf:protobuf-lite:3.0.1'
+
+    //extract google's common protos like Timestamp from protobuf-java, since protobuf-lite does not package them
+    protobuf 'com.google.protobuf:protobuf-java:3.0.2'
+
     implementation ('io.grpc:grpc-okhttp:1.21.0') {
         exclude group: 'com.squareup.okio', module:'okio'
     }
@@ -67,9 +71,7 @@ dependencies {
     implementation 'io.grpc:grpc-protobuf-lite:1.21.0'
     implementation 'io.grpc:grpc-stub:1.21.0'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
-    implementation ('com.google.api.grpc:googleapis-common-protos:0.0.3') {
-        exclude group: 'io.grpc', module:'grpc-protobuf'
-    }
+
     implementation ('org.slf4j:slf4j-api:1.7.25') {
         force = true // don't upgrade to "1.8.0-alpha2"
     }

--- a/src/main/java/com/heroiclabs/nakama/Client.java
+++ b/src/main/java/com/heroiclabs/nakama/Client.java
@@ -56,10 +56,9 @@ public interface Client {
      * Create a new socket from the client.
      * @param port The port number of the server. Default should be 7350.
      * @param socketTimeoutMs Sets the connect, read and write timeout for new connections.
-     * @param socketPingMs The interval at which to send Ping frames to the server.
      * @return a new SocketClient instance.
      */
-    SocketClient createSocket(final int port, final int socketTimeoutMs, final int socketPingMs);
+    SocketClient createSocket(final int port, final int socketTimeoutMs);
 
     /**
      * Create a new socket from the client.
@@ -77,6 +76,16 @@ public interface Client {
      * @return a new SocketClient instance.
      */
     SocketClient createSocket(final String host, final int port, final boolean ssl);
+
+    /**
+     * Create a new socket from the client.
+     * @param host The host URL of the server.
+     * @param port The port number of the server. Default should be 7350.
+     * @param ssl Whether to use SSL to connect to the server.
+     * @param socketTimeoutMs Sets the connect, read and write timeout for new connections.
+     * @return a new SocketClient instance.
+     */
+    SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs);
 
     /**
      * Create a new socket from the client.

--- a/src/main/java/com/heroiclabs/nakama/Client.java
+++ b/src/main/java/com/heroiclabs/nakama/Client.java
@@ -56,9 +56,10 @@ public interface Client {
      * Create a new socket from the client.
      * @param port The port number of the server. Default should be 7350.
      * @param socketTimeoutMs Sets the connect, read and write timeout for new connections.
+     * @param socketPingMs The interval at which to send Ping frames to the server.
      * @return a new SocketClient instance.
      */
-    SocketClient createSocket(final int port, final int socketTimeoutMs);
+    SocketClient createSocket(final int port, final int socketTimeoutMs, final int socketPingMs);
 
     /**
      * Create a new socket from the client.
@@ -83,9 +84,10 @@ public interface Client {
      * @param port The port number of the server. Default should be 7350.
      * @param ssl Whether to use SSL to connect to the server.
      * @param socketTimeoutMs Sets the connect, read and write timeout for new connections.
+     * @param socketPingMs The interval at which to send Ping frames to the server.
      * @return a new SocketClient instance.
      */
-    SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs);
+    SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs, final int socketPingMs);
 
     /**
      * Add one or more friends by id.

--- a/src/main/java/com/heroiclabs/nakama/DefaultClient.java
+++ b/src/main/java/com/heroiclabs/nakama/DefaultClient.java
@@ -174,13 +174,18 @@ public class DefaultClient implements Client {
     }
 
     @Override
-    public SocketClient createSocket(final int port, final int socketTimeoutMs, final int socketPingMs) {
-        return new WebSocketClient(host, port, ssl, socketTimeoutMs, socketPingMs, this.trace);
+    public SocketClient createSocket(final int port, final int socketTimeoutMs) {
+        return new WebSocketClient(host, port, ssl, socketTimeoutMs, WebSocketClient.DEFAULT_PING_MS, this.trace);
     }
 
     @Override
     public SocketClient createSocket(final String host, final int port, final boolean ssl) {
         return new WebSocketClient(host, port, ssl, WebSocketClient.DEFAULT_TIMEOUT_MS, WebSocketClient.DEFAULT_PING_MS, this.trace);
+    }
+
+    @Override
+    public SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs) {
+        return new WebSocketClient(host, port, ssl, socketTimeoutMs, WebSocketClient.DEFAULT_PING_MS, this.trace);
     }
 
     @Override

--- a/src/main/java/com/heroiclabs/nakama/DefaultClient.java
+++ b/src/main/java/com/heroiclabs/nakama/DefaultClient.java
@@ -165,7 +165,7 @@ public class DefaultClient implements Client {
 
     @Override
     public SocketClient createSocket(final int port) {
-        return createSocket(port, 5000);
+        return createSocket(port, 5000, 5000);
     }
 
     @Override
@@ -174,18 +174,18 @@ public class DefaultClient implements Client {
     }
 
     @Override
-    public SocketClient createSocket(final int port, final int socketTimeoutMs) {
-        return new WebSocketClient(host, port, ssl, socketTimeoutMs, this.trace);
+    public SocketClient createSocket(final int port, final int socketTimeoutMs, final int socketPingMs) {
+        return new WebSocketClient(host, port, ssl, socketTimeoutMs, socketPingMs, this.trace);
     }
 
     @Override
     public SocketClient createSocket(final String host, final int port, final boolean ssl) {
-        return new WebSocketClient(host, port, ssl, 5000, this.trace);
+        return new WebSocketClient(host, port, ssl, 5000, 5000, this.trace);
     }
 
     @Override
-    public SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs) {
-        return new WebSocketClient(host, port, ssl, socketTimeoutMs, this.trace);
+    public SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs, final int socketPingMs) {
+        return new WebSocketClient(host, port, ssl, socketTimeoutMs, socketPingMs, this.trace);
     }
 
     @Override

--- a/src/main/java/com/heroiclabs/nakama/DefaultClient.java
+++ b/src/main/java/com/heroiclabs/nakama/DefaultClient.java
@@ -165,7 +165,7 @@ public class DefaultClient implements Client {
 
     @Override
     public SocketClient createSocket(final int port) {
-        return createSocket(port, 5000, 5000);
+        return createSocket(port, WebSocketClient.DEFAULT_TIMEOUT_MS, WebSocketClient.DEFAULT_PING_MS);
     }
 
     @Override
@@ -180,7 +180,7 @@ public class DefaultClient implements Client {
 
     @Override
     public SocketClient createSocket(final String host, final int port, final boolean ssl) {
-        return new WebSocketClient(host, port, ssl, 5000, 5000, this.trace);
+        return new WebSocketClient(host, port, ssl, WebSocketClient.DEFAULT_TIMEOUT_MS, WebSocketClient.DEFAULT_PING_MS, this.trace);
     }
 
     @Override

--- a/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
+++ b/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
@@ -70,7 +70,7 @@ public class WebSocketClient implements SocketClient {
     private final ExecutorService listenerThreadPoolExec = Executors.newCachedThreadPool();
 
     WebSocketClient(@NonNull final String host, final int port, final boolean ssl,
-                    final int socketTimeoutMs, final boolean trace) {
+                    final int socketTimeoutMs, final int socketPingMs, final boolean trace) {
         this.host = host;
         this.port = port;
         this.ssl = ssl;
@@ -81,7 +81,7 @@ public class WebSocketClient implements SocketClient {
                 .connectTimeout(socketTimeoutMs, TimeUnit.MILLISECONDS)
                 .readTimeout(socketTimeoutMs, TimeUnit.MILLISECONDS)
                 .writeTimeout(socketTimeoutMs, TimeUnit.MILLISECONDS)
-                .pingInterval(0, TimeUnit.SECONDS)
+                .pingInterval(socketPingMs, TimeUnit.SECONDS)
                 .build();
     }
 

--- a/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
+++ b/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
@@ -54,6 +54,12 @@ public class WebSocketClient implements SocketClient {
         }
     }
 
+    // The connect, read and write timeout for new connections.
+    public static final int DEFAULT_TIMEOUT_MS = 5000;
+
+    // The interval at which to send Ping frames to the server.
+    public static final int DEFAULT_PING_MS = 5000;
+
     static final Gson GSON = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .registerTypeHierarchyAdapter(byte[].class, new ByteArrayToBase64TypeAdapter())


### PR DESCRIPTION
Fairly self-explanatory. 

For testing whether the transitive dependency is removed, you can run `./gradlew -q dependencies --configuration runtimeClasspath`. On master, `protobuf-java` does show up due to the dependency on the common protos. The new approach looks odd but is documented here: https://github.com/google/protobuf-gradle-plugin#protos-in-dependencies

And obviously now if you run that command there is no `protobuf-java` dependency.