### PR TITLE
merge service files when creating shadow jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,6 +262,10 @@ task javadocJar(type: Jar) {
      }
  }
 
+shadowJar {
+    mergeServiceFiles()
+}
+
 task relocateShadowJar(type: ConfigureShadowRelocation) {
     target = tasks.shadowJar
     prefix = "nakama" // prefix all classpath entries with `nakama`


### PR DESCRIPTION
Closes #38 

By default, shadowJar does not appear to merge service files from various dependencies into the same folder. Therefore, important services like `NameResolver` go unimplemented. 

To be honest it's unclear why shadowJar doesn't default to this behavior but 🤷 