### PR TITLE
include the concrete logger implementation for shadowJar only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,14 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    implementation
+    api
+    annotationProcessor
+    testCompile
+    shadowOnly
+}
+
 dependencies {
     // syntax sugaring for data models
     annotationProcessor 'org.projectlombok:lombok:1.18.12'
@@ -74,14 +82,13 @@ dependencies {
     implementation 'io.grpc:grpc-protobuf-lite:1.31.1'
     implementation 'io.grpc:grpc-stub:1.31.1'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
-    implementation 'org.slf4j:slf4j-simple:1.7.30'
     implementation ('com.google.api.grpc:googleapis-common-protos:0.0.3') {
         exclude group: 'io.grpc', module:'grpc-protobuf'
     }
 
     implementation 'org.slf4j:slf4j-api:1.7.30'
-
     api 'com.google.guava:guava:29.0-android' // listenable future is part of the SDK public API
+    shadowOnly  'org.slf4j:slf4j-simple:1.7.30'
 
     testCompile 'junit:junit:4.12'
 }
@@ -230,10 +237,7 @@ publishing {
 
 shadowJar {
     mergeServiceFiles()
-    dependencies {
-        // provide an actual logger implementation for self-contained shadow jar
-        exclude(dependency('org.slf4j:slf4j-simple:1.7.30'))
-    }
+    configurations = [project.configurations.runtimeClasspath, project.configurations.shadowOnly]
 }
 
 task relocateShadowJar(type: ConfigureShadowRelocation) {


### PR DESCRIPTION
For our regular jar, we ship just the interface to the SL4J logger so that our users can provide their own.

It seems to me that the fatJar should just ship a basic implementation since it's supposed to be self-contained.

I previously attempted this in #41 but wrote it incorrectly.
