### PR TITLE
Fix Eclipse/IDEA support and web socket message executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ socket.connect(session, listener).get();
 System.out.println("Socket connected successfully.");
 ```
 
+By default, all socket messages are processed in a single thread. Advanced users who want to pass a multithreaded `ExecutorService` to the `client.createSocket` method should be aware that incoming messages
+will not necessarily be processed in order by that socket.
+
 ### For Android
 
 Android uses a permissions system which determines which platform services the application will request to use and ask permission for from the user. The client uses the network to communicate with the server so you must add the "INTERNET" permission.

--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ socket.connect(session, listener).get();
 System.out.println("Socket connected successfully.");
 ```
 
-By default, all socket messages are processed in a single thread. Advanced users who want to pass a multithreaded `ExecutorService` to the `client.createSocket` method should be aware that incoming messages
-will not necessarily be processed in order by that socket.
+By default, all socket messages are processed in a single thread. Advanced users who want to pass a multithreaded `ExecutorService` to the `client.createSocket` method should be aware that incoming messages will not necessarily be processed in order by that socket.
 
 ### For Android
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
+import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
 // dependencies required by the gradle build script itself
 buildscript {
@@ -101,7 +102,7 @@ sourceSets {
 idea {
     module {
         sourceDirs += file("${protobuf.generatedFilesBaseDir}/main/grpc");
-        sourceDirs += file("${protobuf.generatedFilesBaseDir}/main/javalite");
+        sourceDirs += file("${protobuf.generatedFilesBaseDir}/main/java");
     }
 }
 
@@ -109,7 +110,11 @@ idea {
 eclipse {
     classpath {
       file {
-            beforeMerged {
+            whenMerged {
+
+                entries += new SourceFolder("build/generated/source/proto/main/grpc", null)
+                entries += new SourceFolder("build/generated/source/proto/main/java", null)
+
                 def grpcSource = entries.find {
                     it.path == "build/generated/source/proto/main/grpc"
                 }
@@ -117,7 +122,7 @@ eclipse {
                 grpcSource.entryAttributes["ignore_optional_problems"] = 'true'
 
                 def javaLiteSource = entries.find {
-                    it.path == "build/generated/source/proto/main/javalite"
+                    it.path == "build/generated/source/proto/main/java"
                 }
 
                 javaLiteSource.entryAttributes["ignore_optional_problems"] = 'true'

--- a/src/main/java/com/heroiclabs/nakama/Client.java
+++ b/src/main/java/com/heroiclabs/nakama/Client.java
@@ -22,6 +22,7 @@ import com.heroiclabs.nakama.api.*;
 import lombok.NonNull;
 
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -97,6 +98,18 @@ public interface Client {
      * @return a new SocketClient instance.
      */
     SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs, final int socketPingMs);
+
+    /**
+     * Create a new socket from the client.
+     * @param host The host URL of the server.
+     * @param port The port number of the server. Default should be 7350.
+     * @param ssl Whether to use SSL to connect to the server.
+     * @param socketTimeoutMs Sets the connect, read and write timeout for new connections.
+     * @param socketPingMs The interval at which to send Ping frames to the server.
+     * @param listenerThreadExec The threading model to use when processing socket messages from the server.
+     * @return a new SocketClient instance.
+     */
+    SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs, final int socketPingMs, ExecutorService listenerThreadExec);
 
     /**
      * Add one or more friends by id.

--- a/src/main/java/com/heroiclabs/nakama/DefaultClient.java
+++ b/src/main/java/com/heroiclabs/nakama/DefaultClient.java
@@ -36,6 +36,8 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -175,22 +177,27 @@ public class DefaultClient implements Client {
 
     @Override
     public SocketClient createSocket(final int port, final int socketTimeoutMs) {
-        return new WebSocketClient(host, port, ssl, socketTimeoutMs, WebSocketClient.DEFAULT_PING_MS, this.trace);
+        return new WebSocketClient(host, port, ssl, socketTimeoutMs, WebSocketClient.DEFAULT_PING_MS, this.trace, Executors.newSingleThreadExecutor());
     }
 
     @Override
     public SocketClient createSocket(final String host, final int port, final boolean ssl) {
-        return new WebSocketClient(host, port, ssl, WebSocketClient.DEFAULT_TIMEOUT_MS, WebSocketClient.DEFAULT_PING_MS, this.trace);
+        return new WebSocketClient(host, port, ssl, WebSocketClient.DEFAULT_TIMEOUT_MS, WebSocketClient.DEFAULT_PING_MS, this.trace, Executors.newSingleThreadExecutor());
     }
 
     @Override
     public SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs) {
-        return new WebSocketClient(host, port, ssl, socketTimeoutMs, WebSocketClient.DEFAULT_PING_MS, this.trace);
+        return new WebSocketClient(host, port, ssl, socketTimeoutMs, WebSocketClient.DEFAULT_PING_MS, this.trace, Executors.newSingleThreadExecutor());
     }
 
     @Override
     public SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs, final int socketPingMs) {
-        return new WebSocketClient(host, port, ssl, socketTimeoutMs, socketPingMs, this.trace);
+        return new WebSocketClient(host, port, ssl, socketTimeoutMs, socketPingMs, this.trace, Executors.newSingleThreadExecutor());
+    }
+
+    @Override
+    public SocketClient createSocket(final String host, final int port, final boolean ssl, final int socketTimeoutMs, final int socketPingMs, ExecutorService listenerThreadExec) {
+        return new WebSocketClient(host, port, ssl, socketTimeoutMs, socketPingMs, this.trace, listenerThreadExec);
     }
 
     @Override

--- a/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
+++ b/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
@@ -74,7 +74,7 @@ public class WebSocketClient implements SocketClient {
     private final OkHttpClient client;
     private final Map<String, SettableFuture<?>> collationIds;
     private WebSocket socket;
-    private final ExecutorService listenerThreadPoolExec = Executors.newCachedThreadPool();
+    private final ExecutorService listenerThreadPoolExec = Executors.newSingleThreadExecutor();
 
     WebSocketClient(@NonNull final String host, final int port, final boolean ssl,
                     final int socketTimeoutMs, final int socketPingMs, final boolean trace) {

--- a/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
+++ b/src/main/java/com/heroiclabs/nakama/WebSocketClient.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -74,15 +73,16 @@ public class WebSocketClient implements SocketClient {
     private final OkHttpClient client;
     private final Map<String, SettableFuture<?>> collationIds;
     private WebSocket socket;
-    private final ExecutorService listenerThreadPoolExec = Executors.newSingleThreadExecutor();
+    private final ExecutorService listenerThreadExec;
 
     WebSocketClient(@NonNull final String host, final int port, final boolean ssl,
-                    final int socketTimeoutMs, final int socketPingMs, final boolean trace) {
+                    final int socketTimeoutMs, final int socketPingMs, final boolean trace, ExecutorService listenerThreadExec) {
         this.host = host;
         this.port = port;
         this.ssl = ssl;
         this.trace = trace;
         this.collationIds = new ConcurrentHashMap<>();
+        this.listenerThreadExec = listenerThreadExec;
 
         client = new OkHttpClient.Builder()
                 .connectTimeout(socketTimeoutMs, TimeUnit.MILLISECONDS)
@@ -157,7 +157,7 @@ public class WebSocketClient implements SocketClient {
 
                 final String collationId = env.getCid();
                 if (collationId == null || "".equals(collationId)) {
-                    listenerThreadPoolExec.execute(new Runnable() {
+                    listenerThreadExec.execute(new Runnable() {
                         @Override
                         public void run() {
                             if (env.getError() != null) {


### PR DESCRIPTION
- Fixes Eclipse and IDEA support for our generated protobuf code. Note, there is still an outstanding issue related to the Eclipse compiler and the newest version of protobuf-javalite https://github.com/protocolbuffers/protobuf/pull/6699 that will spam errors to users and contributors with Eclipse-based IDEs. It's possible that downgrading protobuf-javalite is the only option.

- Ensures that web socket events are dispatched in-order by processing them on a single thread. @mofirouz it's easy enough to allow the user to specify this, but I was wondering if we even wanted to do that since it could break ordering guarantees expected in a Web Socket connection.