### PR TITLE
DefaultError: allow null collationId in constructor

### DIFF
--- a/src/main/java/com/heroiclabs/nakama/DefaultError.java
+++ b/src/main/java/com/heroiclabs/nakama/DefaultError.java
@@ -30,7 +30,7 @@ class DefaultError extends Error {
         this.collationId = null;
     }
 
-    DefaultError(@NonNull final String collationId, @NonNull final WebSocketError error) {
+    DefaultError(final String collationId, @NonNull final WebSocketError error) {
         super(error.getMessage());
         this.code = ErrorCode.fromInt(error.getCode());
         this.collationId = collationId;


### PR DESCRIPTION
Fixes: Crash because of NPE caused by `null` being passed to `DefaultError` constructor in `WebSocketClient#OnMessage` here: 
https://github.com/heroiclabs/nakama-java/blob/master/src/main/java/com/heroiclabs/nakama/WebSocketClient.java#L164

`collationId` can be null because: 
https://github.com/heroiclabs/nakama-java/blob/master/src/main/java/com/heroiclabs/nakama/WebSocketClient.java#L159